### PR TITLE
Move reexec.Init() earlier

### DIFF
--- a/cmd/glogflags.go
+++ b/cmd/glogflags.go
@@ -13,10 +13,14 @@ func GLog(flags *pflag.FlagSet) {
 	if flag := from.Lookup("v"); flag != nil {
 		level := flag.Value.(*glog.Level)
 		levelPtr := (*int32)(level)
-		flags.Int32Var(levelPtr, "loglevel", 0, "Set the level of log output (0-10)")
+		levelPtrIgnored := (*int32)(level)
+		flags.Int32Var(levelPtr, "loglevelreal", 5, "Set the level of log output (0-10)")
+
+		flags.Int32Var(levelPtrIgnored, "loglevel", 5, "Set the level of log output (0-10)")
 		if flags.Lookup("v") == nil {
-			flags.Int32Var(levelPtr, "v", 0, "Set the level of log output (0-10)")
+			flags.Int32Var(levelPtrIgnored, "v", 5, "Set the level of log output (0-10)")
 		}
+
 	}
 	if flag := from.Lookup("vmodule"); flag != nil {
 		value := flag.Value

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/containers/storage/pkg/reexec"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apiserver/pkg/util/logs"
@@ -18,6 +19,10 @@ import (
 )
 
 func main() {
+	if reexec.Init() {
+		return
+	}
+
 	logs.InitLogs()
 	defer logs.FlushLogs()
 	defer serviceability.BehaviorOnPanic(os.Getenv("OPENSHIFT_ON_PANIC"), version.Get())()

--- a/pkg/build/builder/cmd/builder.go
+++ b/pkg/build/builder/cmd/builder.go
@@ -10,7 +10,6 @@ import (
 	istorage "github.com/containers/image/storage"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
-	"github.com/containers/storage/pkg/reexec"
 
 	s2iapi "github.com/openshift/source-to-image/pkg/api"
 	s2igit "github.com/openshift/source-to-image/pkg/scm/git"
@@ -299,7 +298,6 @@ func (s2iBuilder) Build(dockerClient bld.DockerClient, sock string, buildsClient
 }
 
 func runBuild(out io.Writer, builder builder) error {
-	reexec.Init()
 	cfg, err := newBuilderConfigFromEnvironment(out, true)
 	if err != nil {
 		return err
@@ -396,8 +394,6 @@ func RunExtractImageContent(out io.Writer) error {
 	case glog.Is(0):
 		serviceability.InitLogrus("WARN")
 	}
-
-	reexec.Init()
 	cfg, err := newBuilderConfigFromEnvironment(out, true)
 	if err != nil {
 		return err

--- a/pkg/build/builder/daemonless.go
+++ b/pkg/build/builder/daemonless.go
@@ -36,7 +36,7 @@ func pullDaemonlessImage(sc types.SystemContext, store storage.Store, imageName 
 
 	_, err := alltransports.ParseImageName("docker://" + imageName)
 	if err != nil {
-		return err
+		return fmt.Errorf("error parsing image name to pull %s: %v", "docker://"+imageName, err)
 	}
 
 	systemContext := sc

--- a/pkg/build/builder/sti.go
+++ b/pkg/build/builder/sti.go
@@ -322,6 +322,7 @@ func (s *S2IBuilder) Build() error {
 	}
 
 	opts := dockerclient.BuildImageOptions{
+		Context:             ctx,
 		Name:                buildTag,
 		RmTmpContainer:      true,
 		ForceRmTmpContainer: true,


### PR DESCRIPTION
reexec.Init() runs a registered routine if it registered itself during init() with a name that matches argv[0].  If a match is found, it runs the specified routine and returns true, indicating that the current copy of the binary was invoked as a subprocess specifically to run that routine, almost certainly by way of reexec.Command().

The cobra initializer also checks argv[0], but returns an error if it doesn't recognize the value, so we need to call reexec.Init() before that to avoid passing it the names of routines that are registered with reexec.